### PR TITLE
Add support for stack frames and expressions evaluation. This enables…

### DIFF
--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinDocumentContext.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinDocumentContext.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.Debugger.Interop;
+using System.Diagnostics;
+using VSMonoDebugger;
+using VSMonoDebugger.Services;
+
+namespace Mono.Debugging.VisualStudio
+{
+    // This class represents a document context to the debugger. A document context represents a location within a source file. 
+    class XamarinDocumentContext : IDebugDocumentContext2
+    {
+        string _fileName;
+        TEXT_POSITION _begPos;
+        TEXT_POSITION _endPos;
+        XamarinMemoryAddress _codeContext;
+
+
+        public XamarinDocumentContext(string fileName, TEXT_POSITION begPos, TEXT_POSITION endPos, XamarinMemoryAddress codeContext)
+        {
+            _fileName = fileName;
+            _begPos = begPos;
+            _endPos = endPos;
+            _codeContext = codeContext;
+        }
+
+
+        #region IDebugDocumentContext2 Members
+
+        // Compares this document context to a given array of document contexts.
+        int IDebugDocumentContext2.Compare(enum_DOCCONTEXT_COMPARE Compare, IDebugDocumentContext2[] rgpDocContextSet, uint dwDocContextSetLen, out uint pdwDocContext)
+        {
+            dwDocContextSetLen = 0;
+            pdwDocContext = 0;
+
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        // Retrieves a list of all code contexts associated with this document context.
+        int IDebugDocumentContext2.EnumCodeContexts(out IEnumDebugCodeContexts2 ppEnumCodeCxts)
+        {
+            ppEnumCodeCxts = null;
+            try
+            {
+                XamarinMemoryAddress[] codeContexts = new XamarinMemoryAddress[1];
+                codeContexts[0] = _codeContext;
+                ppEnumCodeCxts = new XamarinCodeContextEnum(codeContexts);
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Gets the document that contains this document context.
+        // This method is for those debug engines that supply documents directly to the IDE.
+        int IDebugDocumentContext2.GetDocument(out IDebugDocument2 ppDocument)
+        {           
+            ppDocument = null;
+            return VisualStudioExtensionConstants.E_FAIL;
+        }
+
+        // Gets the language associated with this document context. We assume C#
+        int IDebugDocumentContext2.GetLanguageInfo(ref string pbstrLanguage, ref Guid pguidLanguage)
+        {
+            pbstrLanguage = "C#";
+            pguidLanguage = DebugEngineGuids.guidLanguageCs;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Gets the displayable name of the document that contains this document context.
+        int IDebugDocumentContext2.GetName(enum_GETNAME_TYPE gnType, out string pbstrFileName)
+        {
+            pbstrFileName = _fileName;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Gets the source code range of this document context.
+        // A source range is the entire range of source code, from the current statement back to just after the previous s
+        // statement that contributed code. The source range is typically used for mixing source statements, including 
+        // comments, with code in the disassembly window.
+        // Sincethis engine does not support the disassembly window, this is not implemented.
+        int IDebugDocumentContext2.GetSourceRange(TEXT_POSITION[] pBegPosition, TEXT_POSITION[] pEndPosition)
+        {
+            throw new NotImplementedException("This method is not implemented");
+        }
+
+        // Gets the file statement range of the document context.
+        // A statement range is the range of the lines that contributed the code to which this document context refers.
+        int IDebugDocumentContext2.GetStatementRange(TEXT_POSITION[] pBegPosition, TEXT_POSITION[] pEndPosition)
+        {
+            try
+            {
+                pBegPosition[0].dwColumn = _begPos.dwColumn;
+                pBegPosition[0].dwLine = _begPos.dwLine;
+
+                pEndPosition[0].dwColumn = _endPos.dwColumn;
+                pEndPosition[0].dwLine = _endPos.dwLine;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Moves the document context by a given number of statements or lines.
+        // This is used primarily to support the Autos window in discovering the proximity statements around 
+        // this document context. 
+        int IDebugDocumentContext2.Seek(int nCount, out IDebugDocumentContext2 ppDocContext)
+        {
+            ppDocContext = null;
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        #endregion
+    }
+}

--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinEnums.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinEnums.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.Debugger.Interop;
+using VSMonoDebugger;
+
+namespace Mono.Debugging.VisualStudio
+{
+    #region Base Class
+    class XamarinEnum<T,I> where I: class
+    {
+        readonly T[] m_data;
+        uint m_position;
+
+        public XamarinEnum(T[] data)
+        {
+            m_data = data;
+            m_position = 0;
+        }
+
+        public int Clone(out I ppEnum)
+        {
+            ppEnum = null;
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        public int GetCount(out uint pcelt)
+        {
+            pcelt = (uint)m_data.Length;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        public int Next(uint celt, T[] rgelt, out uint celtFetched)
+        {
+            return Move(celt, rgelt, out celtFetched);
+        }
+
+        public int Reset()
+        {
+            lock (this)
+            {
+                m_position = 0;
+
+                return VisualStudioExtensionConstants.S_OK;
+            }
+        }
+
+        public int Skip(uint celt)
+        {
+            uint celtFetched;
+
+            return Move(celt, null, out celtFetched);
+        }
+
+        private int Move(uint celt, T[] rgelt, out uint celtFetched)
+        {
+            lock (this)
+            {
+                int hr = VisualStudioExtensionConstants.S_OK;
+                celtFetched = (uint)m_data.Length - m_position;
+
+                if (celt > celtFetched)
+                {
+                    hr = VisualStudioExtensionConstants.S_FALSE;
+                }
+                else if (celt < celtFetched)
+                {
+                    celtFetched = celt;
+                }
+
+                if (rgelt != null)
+                {
+                    for (int c = 0; c < celtFetched; c++)
+                    {
+                        rgelt[c] = m_data[m_position + c];
+                    }
+                }
+
+                m_position += celtFetched;
+
+                return hr;
+            }
+        }
+    }
+    #endregion Base Class
+
+    class XamarinProgramEnum : XamarinEnum<IDebugProgram2, IEnumDebugPrograms2>, IEnumDebugPrograms2
+    {
+        public XamarinProgramEnum(IDebugProgram2[] data) : base(data)
+        {
+        }
+
+        public int Next(uint celt, IDebugProgram2[] rgelt, ref uint celtFetched)
+        {
+            return Next(celt, rgelt, out celtFetched);
+        }
+    }
+
+    class XamarinFrameInfoEnum : XamarinEnum<FRAMEINFO, IEnumDebugFrameInfo2>, IEnumDebugFrameInfo2
+    {
+        public XamarinFrameInfoEnum(FRAMEINFO[] data)
+            : base(data)
+        {
+        }
+
+        public int Next(uint celt, FRAMEINFO[] rgelt, ref uint celtFetched)
+        {
+            return Next(celt, rgelt, out celtFetched);
+        }
+    }
+
+    class XamarinPropertyInfoEnum : XamarinEnum<DEBUG_PROPERTY_INFO, IEnumDebugPropertyInfo2>, IEnumDebugPropertyInfo2
+    {
+        public XamarinPropertyInfoEnum(DEBUG_PROPERTY_INFO[] data)
+            : base(data)
+        {
+        }
+    }
+
+    class XamarinThreadEnum : XamarinEnum<IDebugThread2, IEnumDebugThreads2>, IEnumDebugThreads2
+    {
+        public XamarinThreadEnum(IDebugThread2[] threads)
+            : base(threads)
+        {
+            
+        }
+
+        public int Next(uint celt, IDebugThread2[] rgelt, ref uint celtFetched)
+        {
+            return Next(celt, rgelt, out celtFetched);
+        }
+    }
+
+    class XamarinModuleEnum : XamarinEnum<IDebugModule2, IEnumDebugModules2>, IEnumDebugModules2
+    {
+        public XamarinModuleEnum(IDebugModule2[] modules)
+            : base(modules)
+        {
+
+        }
+
+        public int Next(uint celt, IDebugModule2[] rgelt, ref uint celtFetched)
+        {
+            return Next(celt, rgelt, out celtFetched);
+        }
+    }
+
+    class XamarinPropertyEnum : XamarinEnum<DEBUG_PROPERTY_INFO, IEnumDebugPropertyInfo2>, IEnumDebugPropertyInfo2
+    {
+        public XamarinPropertyEnum(DEBUG_PROPERTY_INFO[] properties)
+            : base(properties)
+        {
+
+        }
+    }
+
+    class XamarinCodeContextEnum : XamarinEnum<IDebugCodeContext2, IEnumDebugCodeContexts2>, IEnumDebugCodeContexts2
+    {
+        public XamarinCodeContextEnum(IDebugCodeContext2[] codeContexts)
+            : base(codeContexts)
+        {
+
+        }
+
+        public int Next(uint celt, IDebugCodeContext2[] rgelt, ref uint celtFetched)
+        {
+            return Next(celt, rgelt, out celtFetched);
+        }
+    }
+
+    class XamarinBoundBreakpointsEnum : XamarinEnum<IDebugBoundBreakpoint2, IEnumDebugBoundBreakpoints2>, IEnumDebugBoundBreakpoints2
+    {
+        public XamarinBoundBreakpointsEnum(IDebugBoundBreakpoint2[] breakpoints)
+            : base(breakpoints)
+        {
+
+        }
+
+        public int Next(uint celt, IDebugBoundBreakpoint2[] rgelt, ref uint celtFetched)
+        {
+            return Next(celt, rgelt, out celtFetched);
+        }
+    }
+
+    class XamarinErrorBreakpointsEnum : XamarinEnum<IDebugErrorBreakpoint2, IEnumDebugErrorBreakpoints2>, IEnumDebugErrorBreakpoints2
+    {
+        public XamarinErrorBreakpointsEnum(IDebugErrorBreakpoint2[] breakpoints)
+            : base(breakpoints)
+        {
+
+        }
+
+        public int Next(uint celt, IDebugErrorBreakpoint2[] rgelt, ref uint celtFetched)
+        {
+            return Next(celt, rgelt, out celtFetched);
+        }
+    }
+}

--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinEvents.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinEvents.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.Debugger.Interop;
+using VSMonoDebugger;
+
+namespace Mono.Debugging.VisualStudio
+{
+    #region Event base classes
+
+    class XamarinAsynchronousEvent : IDebugEvent2
+    {
+        public const uint Attributes = (uint)enum_EVENTATTRIBUTES.EVENT_ASYNCHRONOUS;
+
+        int IDebugEvent2.GetAttributes(out uint eventAttributes)
+        {
+            eventAttributes = Attributes;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+    }
+    
+    #endregion
+    
+    sealed class XamarinExpressionEvaluationCompleteEvent : XamarinAsynchronousEvent, IDebugExpressionEvaluationCompleteEvent2
+    {
+        public const string IID = "C0E13A85-238A-4800-8315-D947C960A843";
+
+        XamarinExpression _expression;
+        XamarinProperty _property;
+        public XamarinExpressionEvaluationCompleteEvent(XamarinExpression expression, XamarinProperty property)
+        {
+            _expression = expression;
+            _property = property;
+        }
+
+        public int GetExpression(out IDebugExpression2 ppExpr)
+        {
+            ppExpr = _expression;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        public int GetResult(out IDebugProperty2 ppResult)
+        {
+            ppResult = _property;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+    }
+
+    // This interface is sent by the debug engine (DE) to the session debug manager (SDM) when a thread is created in a program being debugged.
+    sealed class XamarinThreadCreateEvent : XamarinAsynchronousEvent, IDebugThreadCreateEvent2
+    {
+        public const string IID = "2090CCFC-70C5-491D-A5E8-BAD2DD9EE3EA";
+    }
+
+    // This interface is sent by the debug engine (DE) to the session debug manager (SDM) when a thread has exited.
+    sealed class XamarinThreadDestroyEvent : XamarinAsynchronousEvent, IDebugThreadDestroyEvent2
+    {
+        public const string IID = "2C3B7532-A36F-4A6E-9072-49BE649B8541";
+
+        readonly uint m_exitCode;
+        public XamarinThreadDestroyEvent(uint exitCode)
+        {
+            m_exitCode = exitCode;
+        }
+
+        #region IDebugThreadDestroyEvent2 Members
+
+        int IDebugThreadDestroyEvent2.GetExitCode(out uint exitCode)
+        {
+            exitCode = m_exitCode;
+            
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        #endregion
+    }
+}

--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinExpression.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinExpression.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.Debugger.Interop;
+using VSMonoDebugger;
+
+namespace Mono.Debugging.VisualStudio
+{
+    // This class represents a succesfully parsed expression to the debugger. 
+    // It is returned as a result of a successful call to IDebugExpressionContext2.ParseText
+    // It allows the debugger to obtain the values of an expression in the debuggee. 
+    class XamarinExpression : IDebugExpression2
+    {
+        readonly XamarinEngine _engine;
+        readonly XamarinThread _thread;
+
+        Mono.Debugging.Client.ObjectValue _var;
+        System.Threading.Thread _asyncEval;
+
+        public XamarinExpression(XamarinEngine engine, XamarinThread thread, Mono.Debugging.Client.ObjectValue var)
+        {
+            _var = var;
+            _asyncEval = null;
+            _engine = engine;
+            _thread = thread;
+        }
+
+        #region IDebugExpression2 Members
+
+        // This method cancels asynchronous expression evaluation as started by a call to the IDebugExpression2::EvaluateAsync method.
+        int IDebugExpression2.Abort()
+        {
+            _asyncEval.Abort();
+            _asyncEval = null;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // This method evaluates the expression asynchronously.
+        // This method should return immediately after it has started the expression evaluation. 
+        // When the expression is successfully evaluated, an IDebugExpressionEvaluationCompleteEvent2 
+        // must be sent to the IDebugEventCallback2 event callback
+        int IDebugExpression2.EvaluateAsync(enum_EVALFLAGS dwFlags, IDebugEventCallback2 pExprCallback)
+        {
+            if(pExprCallback == null)
+                return VisualStudioExtensionConstants.S_FALSE;
+
+            if (_asyncEval == null || _asyncEval.ThreadState != System.Threading.ThreadState.Running)
+            {
+                _asyncEval = new System.Threading.Thread(() =>
+                {
+                    uint attributes;
+                    Guid riidEvent = new Guid(XamarinExpressionEvaluationCompleteEvent.IID);
+                    IDebugExpressionEvaluationCompleteEvent2 evnt = new XamarinExpressionEvaluationCompleteEvent(this, new XamarinProperty(_var));
+                    IDebugEvent2 eventObject = evnt as IDebugEvent2;
+                    if (eventObject.GetAttributes(out attributes) != VisualStudioExtensionConstants.S_OK)
+                        throw new InvalidOperationException("Failed to create and register a thread. The event object failed to get its attributes");
+                    if (pExprCallback.Event(_engine.MonoEngine, null, _engine.ActiveProgram, _thread, eventObject, ref riidEvent, attributes) != VisualStudioExtensionConstants.S_OK)
+                        throw new InvalidOperationException("Failed to create and register a thread. The event has not been sent succesfully");
+                });
+                _asyncEval.Start();
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            return VisualStudioExtensionConstants.S_FALSE;
+        }
+
+        // This method evaluates the expression synchronously.
+        int IDebugExpression2.EvaluateSync(enum_EVALFLAGS dwFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
+        {
+            ppResult = new XamarinProperty(_var);
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        #endregion
+    }
+}

--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinMemoryAddress.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinMemoryAddress.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.Debugger.Interop;
+using VSMonoDebugger;
+using VSMonoDebugger.Services;
+
+namespace Mono.Debugging.VisualStudio
+{
+    class XamarinMemoryAddress : IDebugCodeContext2
+    {
+        readonly XamarinEngine _engine;
+        readonly uint _address;
+        IDebugDocumentContext2 _documentContext;
+        
+        public XamarinMemoryAddress(XamarinEngine engine, uint address)
+        {
+            _engine = engine;
+            _address = address;
+        }
+
+        public void SetDocumentContext(IDebugDocumentContext2 docContext)
+        {
+            _documentContext = docContext;
+        }
+
+        #region IDebugCodeContext2 Members
+
+        // Gets the document context for this code-context
+        public int GetDocumentContext(out IDebugDocumentContext2 ppSrcCxt)
+        {
+            ppSrcCxt = _documentContext;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Gets the language information for this code context.
+        public int GetLanguageInfo(ref string pbstrLanguage, ref Guid pguidLanguage)
+        {
+            if (_documentContext != null)
+            {
+                _documentContext.GetLanguageInfo(ref pbstrLanguage, ref pguidLanguage);
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            else
+            {
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Adds a specified value to the current context's address to create a new context.
+        public int Add(ulong dwCount, out IDebugMemoryContext2 newAddress)
+        {
+            newAddress = new XamarinMemoryAddress(_engine, (uint)dwCount + _address);
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Compares the memory context to each context in the given array in the manner indicated by compare flags, 
+        // returning an index of the first context that matches.
+        public int Compare(enum_CONTEXT_COMPARE uContextCompare, IDebugMemoryContext2[] compareToItems, uint compareToLength, out uint foundIndex)
+        {
+            foundIndex = uint.MaxValue;
+
+            try
+            {
+                enum_CONTEXT_COMPARE contextCompare = (enum_CONTEXT_COMPARE)uContextCompare;
+
+                for (uint c = 0; c < compareToLength; c++)
+                {
+                    XamarinMemoryAddress compareTo = compareToItems[c] as XamarinMemoryAddress;
+                    if (compareTo == null)
+                    {
+                        continue;
+                    }
+
+                    if (!XamarinEngine.ReferenceEquals(this._engine, compareTo._engine))
+                    {
+                        continue;
+                    }
+
+                    bool result;
+
+                    switch (contextCompare)
+                    {
+                        case enum_CONTEXT_COMPARE.CONTEXT_EQUAL:
+                            result = (this._address == compareTo._address);
+                            break;
+
+                        case enum_CONTEXT_COMPARE.CONTEXT_LESS_THAN:
+                            result = (this._address < compareTo._address);
+                            break;
+
+                        case enum_CONTEXT_COMPARE.CONTEXT_GREATER_THAN:
+                            result = (this._address > compareTo._address);
+                            break;
+
+                        case enum_CONTEXT_COMPARE.CONTEXT_LESS_THAN_OR_EQUAL:
+                            result = (this._address <= compareTo._address);
+                            break;
+
+                        case enum_CONTEXT_COMPARE.CONTEXT_GREATER_THAN_OR_EQUAL:
+                            result = (this._address >= compareTo._address);
+                            break;
+
+                        // The sample debug engine doesn't understand scopes or functions
+                        case enum_CONTEXT_COMPARE.CONTEXT_SAME_SCOPE:
+                        case enum_CONTEXT_COMPARE.CONTEXT_SAME_FUNCTION:
+                            result = (this._address == compareTo._address);
+                            break;
+
+                        case enum_CONTEXT_COMPARE.CONTEXT_SAME_MODULE:
+                            result = (this._address == compareTo._address);
+                            /*if (result == false)
+                            {
+                                DebuggedModule module = m_engine.DebuggedProcess.ResolveAddress(m_address);
+
+                                if (module != null)
+                                {
+                                    result = (compareTo.m_address >= module.BaseAddress) &&
+                                        (compareTo.m_address < module.BaseAddress + module.Size);
+                                }
+                            }*/
+                            break;
+
+                        case enum_CONTEXT_COMPARE.CONTEXT_SAME_PROCESS:
+                            result = true;
+                            break;
+
+                        default:
+                            // A new comparison was invented that we don't support
+                            return VisualStudioExtensionConstants.E_NOTIMPL;
+                    }
+
+                    if (result)
+                    {
+                        foundIndex = c;
+                        return VisualStudioExtensionConstants.S_OK;
+                    }
+                }
+
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Gets information that describes this context.
+        public int GetInfo(enum_CONTEXT_INFO_FIELDS dwFields, CONTEXT_INFO[] pinfo)
+        {
+            try
+            {
+                pinfo[0].dwFields = 0;
+
+                if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_ADDRESS) != 0)
+                {
+                    pinfo[0].bstrAddress = _address.ToString();
+                    pinfo[0].dwFields |= enum_CONTEXT_INFO_FIELDS.CIF_ADDRESS;
+                }
+
+                // Fields not supported by the sample
+                if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_ADDRESSOFFSET) != 0) { }
+                if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_ADDRESSABSOLUTE) != 0) { }
+                if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_MODULEURL) != 0) { }
+                if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_FUNCTION) != 0) { }
+                if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_FUNCTIONOFFSET) != 0) { }
+
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Gets the user-displayable name for this context
+        // This is not supported by the sample engine.
+        public int GetName(out string pbstrName)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Subtracts a specified value from the current context's address to create a new context.
+        public int Subtract(ulong dwCount, out IDebugMemoryContext2 ppMemCxt)
+        {
+            ppMemCxt = new XamarinMemoryAddress(_engine, (uint)dwCount - _address);
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        #endregion
+    }
+}

--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinProperty.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinProperty.cs
@@ -1,0 +1,154 @@
+﻿using Microsoft.VisualStudio.Debugger.Interop;
+using System;
+using VSMonoDebugger;
+
+namespace Mono.Debugging.VisualStudio
+{
+    public class XamarinProperty : IDebugProperty2
+    {
+        Mono.Debugging.Client.ObjectValue _objectValue;
+
+        public XamarinProperty(Mono.Debugging.Client.ObjectValue objectValue)
+        {
+            _objectValue = objectValue;
+        }
+
+        // Construct a DEBUG_PROPERTY_INFO representing this local or parameter.
+        public DEBUG_PROPERTY_INFO ConstructDebugPropertyInfo(enum_DEBUGPROP_INFO_FLAGS dwFields)
+        {
+            DEBUG_PROPERTY_INFO propertyInfo = new DEBUG_PROPERTY_INFO();
+
+            if ((dwFields & enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_FULLNAME) != 0)
+            {
+                propertyInfo.bstrFullName = _objectValue.Name;
+                propertyInfo.dwFields |= enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_FULLNAME;
+            }
+
+            if ((dwFields & enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_NAME) != 0)
+            {
+                propertyInfo.bstrName = _objectValue.Name;
+                propertyInfo.dwFields |= enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_NAME;
+            }
+
+            if ((dwFields & enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_TYPE) != 0)
+            {
+                propertyInfo.bstrType = _objectValue.TypeName;
+                propertyInfo.dwFields |= enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_TYPE;
+            }
+
+            if ((dwFields & enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_VALUE) != 0)
+            {
+                propertyInfo.bstrValue = _objectValue.Value;
+                propertyInfo.dwFields |= enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_VALUE;
+            }
+
+            if ((dwFields & enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_ATTRIB) != 0)
+            {
+                // The sample does not support writing of values displayed in the debugger, so mark them all as read-only.
+                propertyInfo.dwAttrib |= enum_DBG_ATTRIB_FLAGS.DBG_ATTRIB_VALUE_READONLY;
+                
+                if (_objectValue.HasChildren)
+                {
+                    propertyInfo.dwAttrib |= enum_DBG_ATTRIB_FLAGS.DBG_ATTRIB_OBJ_IS_EXPANDABLE;
+                }
+            }
+
+            // Provide this property pointer as the property info
+            propertyInfo.pProperty = (IDebugProperty2)this;
+            propertyInfo.dwFields |= enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_PROP;
+
+            return propertyInfo;
+        }
+
+        #region IDebugProperty2 Members
+
+        // Enumerates the children of a property. This provides support for dereferencing pointers, displaying members of an array, or fields of a class or struct.
+        public int EnumChildren(enum_DEBUGPROP_INFO_FLAGS dwFields, uint dwRadix, ref System.Guid guidFilter, enum_DBG_ATTRIB_FLAGS dwAttribFilter, string pszNameFilter, uint dwTimeout, out IEnumDebugPropertyInfo2 ppEnum)
+        {
+            ppEnum = null;
+
+            if (_objectValue.HasChildren)
+            {
+                var children = this._objectValue.GetAllChildren();
+                DEBUG_PROPERTY_INFO[] properties = new DEBUG_PROPERTY_INFO[children.Length];
+                for(int i = 0; i < children.Length; ++i)
+                {
+                    properties[i] = (new XamarinProperty(children[i])).ConstructDebugPropertyInfo(dwFields);
+                }
+                ppEnum = new XamarinPropertyEnum(properties);
+                return VisualStudioExtensionConstants.S_OK;
+            }
+
+            return VisualStudioExtensionConstants.S_FALSE;
+        }
+
+        // Returns the property that describes the most-derived property of a property
+        // This is called to support object oriented languages. It allows the debug engine to return an IDebugProperty2 for the most-derived 
+        // object in a hierarchy. This engine does not support this.
+        public int GetDerivedMostProperty(out IDebugProperty2 ppDerivedMost)
+        {
+            throw new NotImplementedException();
+        }
+
+        // This method exists for the purpose of retrieving information that does not lend itself to being retrieved by calling the IDebugProperty2::GetPropertyInfo 
+        // method. This includes information about custom viewers, managed type slots and other information.
+        public int GetExtendedInfo(ref System.Guid guidExtendedInfo, out object pExtendedInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Returns the memory bytes for a property value.
+        public int GetMemoryBytes(out IDebugMemoryBytes2 ppMemoryBytes)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Returns the memory context for a property value.
+        public int GetMemoryContext(out IDebugMemoryContext2 ppMemory)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Returns the parent of a property.
+        public int GetParent(out IDebugProperty2 ppParent)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Fills in a DEBUG_PROPERTY_INFO structure that describes a property.
+        public int GetPropertyInfo(enum_DEBUGPROP_INFO_FLAGS dwFields, uint dwRadix, uint dwTimeout, IDebugReference2[] rgpArgs, uint dwArgCount, DEBUG_PROPERTY_INFO[] pPropertyInfo)
+        {
+            pPropertyInfo[0] = new DEBUG_PROPERTY_INFO();
+            rgpArgs = null;
+            pPropertyInfo[0] = ConstructDebugPropertyInfo(dwFields);
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        //  Return an IDebugReference2 for this property. An IDebugReference2 can be thought of as a type and an address.
+        public int GetReference(out IDebugReference2 ppReference)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Returns the size, in bytes, of the property value.
+        public int GetSize(out uint pdwSize)
+        {
+            throw new NotImplementedException();
+        }
+
+        // The debugger will call this when the user tries to edit the property's values
+        public int SetValueAsReference(IDebugReference2[] rgpArgs, uint dwArgCount, IDebugReference2 pValue, uint dwTimeout)
+        {
+            throw new NotImplementedException();
+        }
+
+        // The debugger will call this when the user tries to edit the property's values in one of the debugger windows.
+        public int SetValueAsString(string pszValue, uint dwRadix, uint dwTimeout)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+    }
+}

--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinStackFrame.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinStackFrame.cs
@@ -1,0 +1,493 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.Debugger.Interop;
+using System.Diagnostics;
+using VSMonoDebugger;
+using VSMonoDebugger.Services;
+
+namespace Mono.Debugging.VisualStudio
+{
+    enum EnumDebugPropertyInfoContents
+    {
+        eNone = 0x0,
+        eLocals = 0x1,
+        eProperties = 0x2,
+        eLocalsAndProperties = 0x3,
+    }
+
+    // Represents a logical stack frame on the thread stack. 
+    // Also implements the IDebugExpressionContext interface, which allows expression evaluation and watch windows.
+    class XamarinStackFrame : IDebugStackFrame2, IDebugExpressionContext2
+    {
+        readonly XamarinEngine _engine;
+        readonly XamarinThread _thread;
+        Mono.Debugging.Client.StackFrame _stackFrame;
+
+        Mono.Debugging.Client.ObjectValue[] _parameters;
+        Mono.Debugging.Client.ObjectValue[] _locals;     
+        Mono.Debugging.Client.ObjectValue _thisObject;
+
+        public XamarinStackFrame(XamarinEngine engine, XamarinThread thread, Mono.Debugging.Client.StackFrame stackFrame)
+        {
+            _engine = engine;
+            _thread = thread;
+            _stackFrame = stackFrame;
+
+            _parameters = _stackFrame.GetParameters();
+            _locals = _stackFrame.GetLocalVariables();
+            _thisObject = _stackFrame.GetThisReference();
+        }
+
+        #region Non-interface methods
+
+        // Construct a FRAMEINFO for this stack frame with the requested information.
+        public FRAMEINFO CreateFrameInfo(enum_FRAMEINFO_FLAGS dwFieldSpec)
+        {
+            FRAMEINFO frameInfo = new FRAMEINFO();
+
+            // The debugger is asking for the formatted name of the function which is displayed in the callstack window.
+            // There are several optional parts to this name including the module, argument types and values, and line numbers.
+            // The optional information is requested by setting flags in the dwFieldSpec parameter.
+            if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME) != 0)
+            {
+                // If there is source information, construct a string that contains the module name, function name, and optionally argument names and values.
+                frameInfo.m_bstrFuncName = "";
+
+                if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_MODULE) != 0)
+                {
+                    frameInfo.m_bstrFuncName = _stackFrame.FullModuleName + "!";
+                }
+
+                frameInfo.m_bstrFuncName += _stackFrame.SourceLocation.MethodName;
+
+                if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0 && _parameters.Length > 0)
+                {
+                    frameInfo.m_bstrFuncName += "(";
+                    for (int i = 0; i < _parameters.Length; i++)
+                    {
+                        if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_TYPES) != 0)
+                        {
+                            frameInfo.m_bstrFuncName += _parameters[i].TypeName + " ";
+                        }
+
+                        if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_NAMES) != 0)
+                        {
+                            frameInfo.m_bstrFuncName += _parameters[i].Name;
+                        }
+
+                        if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_VALUES) != 0)
+                        {
+                            frameInfo.m_bstrFuncName += "=" + _parameters[i].Value;
+                        }
+
+                        if (i < _parameters.Length - 1)
+                        {
+                            frameInfo.m_bstrFuncName += ", ";
+                        }
+                    }
+                    frameInfo.m_bstrFuncName += ")";
+                }
+
+                if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_LINES) != 0)
+                {
+                    frameInfo.m_bstrFuncName += " Line:" + _stackFrame.SourceLocation.Line.ToString();
+                }
+
+                frameInfo.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_FUNCNAME;
+            }
+
+            // The debugger is requesting the name of the module for this stack frame.
+            if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_MODULE) != 0)
+            {
+                frameInfo.m_bstrModule = _stackFrame.FullModuleName;
+                frameInfo.m_dwValidFields |=  enum_FRAMEINFO_FLAGS.FIF_MODULE;
+            }
+
+            // The debugger is requesting the range of memory addresses for this frame.
+            // For the sample engine, this is the contents of the frame pointer.
+            if ((dwFieldSpec &  enum_FRAMEINFO_FLAGS.FIF_STACKRANGE) != 0)
+            {
+                /*frameInfo.m_addrMin = m_threadContext.ebp;
+                frameInfo.m_addrMax = m_threadContext.ebp;
+                frameInfo.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_STACKRANGE;*/
+            }
+
+            // The debugger is requesting the IDebugStackFrame2 value for this frame info.
+            if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FRAME) != 0)
+            {
+                frameInfo.m_pFrame = this;
+                frameInfo.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_FRAME;
+            }
+            
+            // Does this stack frame of symbols loaded?
+            if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_DEBUGINFO) != 0)
+            {
+                frameInfo.m_fHasDebugInfo = _stackFrame.HasDebugInfo ? 1 : 0;
+                frameInfo.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_DEBUGINFO;
+            }
+
+            // Is this frame stale?
+            if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_STALECODE) != 0)
+            {
+                frameInfo.m_fStaleCode = 0;
+                frameInfo.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_STALECODE;
+            }
+
+            // The debugger would like a pointer to the IDebugModule2 that contains this stack frame.
+            /*if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_DEBUG_MODULEP) != 0)
+            {
+                if (module != null)
+                {
+                    XamarinModule XamarinModule = (XamarinModule)module.Client;
+                    Debug.Assert(XamarinModule != null);
+                    frameInfo.m_pModule = XamarinModule;
+                    frameInfo.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_DEBUG_MODULEP;
+                }
+            }*/
+
+            return frameInfo;
+        }
+
+        // Construct an instance of IEnumDebugPropertyInfo2 for the combined locals and parameters.
+        private void CreateLocalsPlusArgsProperties(EnumDebugPropertyInfoContents contents, out uint elementsReturned, out IEnumDebugPropertyInfo2 enumObject)
+        {
+            elementsReturned = 0;
+            if ((contents & EnumDebugPropertyInfoContents.eLocals) != 0)
+            {
+                if (_thisObject != null)
+                {
+                    elementsReturned += elementsReturned + 1;
+                }
+                elementsReturned += (uint)_locals.Length;
+            }
+            if ((contents & EnumDebugPropertyInfoContents.eProperties) != 0)
+            {
+                elementsReturned += (uint)_parameters.Length;
+            }
+
+            DEBUG_PROPERTY_INFO[] propInfo = new DEBUG_PROPERTY_INFO[elementsReturned];
+            int propInfoIdx = 0;
+
+            if ((contents & EnumDebugPropertyInfoContents.eLocals) != 0)
+            {
+                if (_thisObject != null)
+                {
+                    propInfo[propInfoIdx++] = new XamarinProperty(_thisObject).ConstructDebugPropertyInfo(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_STANDARD);
+                }
+
+                for (int i = 0; i < _locals.Length; i++)
+                {
+                    propInfo[propInfoIdx++] = new XamarinProperty(_locals[i]).ConstructDebugPropertyInfo(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_STANDARD);
+                }
+            }
+
+            if ((contents & EnumDebugPropertyInfoContents.eProperties) != 0)
+            {
+                for (int i = 0; i < _parameters.Length; i++)
+                {
+                    propInfo[propInfoIdx++] = new XamarinProperty(_parameters[i]).ConstructDebugPropertyInfo(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_STANDARD);
+                }
+            }
+
+            enumObject = new XamarinPropertyInfoEnum(propInfo);
+        }
+
+        #endregion
+
+        #region IDebugStackFrame2 Members
+
+        // Creates an enumerator for properties associated with the stack frame, such as local variables.
+        // The sample engine only supports returning locals and parameters. Other possible values include
+        // class fields (this pointer), registers, exceptions...
+        int IDebugStackFrame2.EnumProperties(enum_DEBUGPROP_INFO_FLAGS dwFields, uint nRadix, ref Guid guidFilter, uint dwTimeout, out uint elementsReturned, out IEnumDebugPropertyInfo2 enumObject)
+        {
+            int hr;
+
+            elementsReturned = 0;
+            enumObject = null;
+            
+            try
+            {
+                if (guidFilter == DebugEngineGuids.guidFilterLocalsPlusArgs ||
+                    guidFilter == DebugEngineGuids.guidFilterAllLocalsPlusArgs ||
+                    guidFilter == DebugEngineGuids.guidFilterAllLocals)        
+                {
+                    CreateLocalsPlusArgsProperties(EnumDebugPropertyInfoContents.eLocalsAndProperties, out elementsReturned, out enumObject);
+                    hr = VisualStudioExtensionConstants.S_OK;
+                }
+                else if (guidFilter == DebugEngineGuids.guidFilterLocals)
+                {
+                    CreateLocalsPlusArgsProperties(EnumDebugPropertyInfoContents.eLocals, out elementsReturned, out enumObject);
+                    hr = VisualStudioExtensionConstants.S_OK;
+                }
+                else if (guidFilter == DebugEngineGuids.guidFilterArgs)
+                {
+                    CreateLocalsPlusArgsProperties(EnumDebugPropertyInfoContents.eLocalsAndProperties, out elementsReturned, out enumObject);
+                    hr = VisualStudioExtensionConstants.S_OK;
+                }
+                else
+                {
+                    hr = VisualStudioExtensionConstants.E_NOTIMPL;
+                }
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+            
+            return hr;
+        }
+
+        // Gets the code context for this stack frame. The code context represents the current instruction pointer in this stack frame.
+        int IDebugStackFrame2.GetCodeContext(out IDebugCodeContext2 memoryAddress)
+        {
+            memoryAddress = null;
+
+            try
+            {
+                memoryAddress = new XamarinMemoryAddress(_engine, 0);
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Gets a description of the properties of a stack frame.
+        // Calling the IDebugProperty2::EnumChildren method with appropriate filters can retrieve the local variables, method parameters, registers, and "this" 
+        // pointer associated with the stack frame. The debugger calls EnumProperties to obtain these values in the sample.
+        int IDebugStackFrame2.GetDebugProperty(out IDebugProperty2 property)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Gets the document context for this stack frame. The debugger will call this when the current stack frame is changed
+        // and will use it to open the correct source document for this stack frame.
+        int IDebugStackFrame2.GetDocumentContext(out IDebugDocumentContext2 docContext)
+        {
+            docContext = null;
+            try
+            {
+                if (_stackFrame.HasDebugInfo)
+                {
+                    // Assume all lines begin and end at the beginning of the line.
+                    TEXT_POSITION begTp = new TEXT_POSITION();
+                    begTp.dwColumn = 0;
+                    begTp.dwLine = (uint)(_stackFrame.SourceLocation.Line > 0 ? _stackFrame.SourceLocation.Line - 1 : 0);
+                    TEXT_POSITION endTp = new TEXT_POSITION();
+                    endTp.dwColumn = 0;
+                    endTp.dwLine = (uint)(_stackFrame.SourceLocation.Line > 0 ? _stackFrame.SourceLocation.Line - 1 : 0);
+                    
+                    docContext = new XamarinDocumentContext(_stackFrame.SourceLocation.FileName, begTp, endTp, null);
+                    return VisualStudioExtensionConstants.S_OK;
+                }
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+
+            return VisualStudioExtensionConstants.S_FALSE;
+        }
+
+        // Gets an evaluation context for expression evaluation within the current context of a stack frame and thread.
+        // Generally, an expression evaluation context can be thought of as a scope for performing expression evaluation. 
+        // Call the IDebugExpressionContext2::ParseText method to parse an expression and then call the resulting IDebugExpression2::EvaluateSync 
+        // or IDebugExpression2::EvaluateAsync methods to evaluate the parsed expression.
+        int IDebugStackFrame2.GetExpressionContext(out IDebugExpressionContext2 ppExprCxt)
+        {
+            ppExprCxt = (IDebugExpressionContext2)this;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Gets a description of the stack frame.
+        int IDebugStackFrame2.GetInfo(enum_FRAMEINFO_FLAGS dwFieldSpec, uint nRadix, FRAMEINFO[] pFrameInfo)
+        {
+            try
+            {
+                pFrameInfo[0] = CreateFrameInfo(dwFieldSpec);
+
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Gets the language associated with this stack frame. 
+        // In this sample, all the supported stack frames are C++
+        int IDebugStackFrame2.GetLanguageInfo(ref string pbstrLanguage, ref Guid pguidLanguage)
+        {
+            pbstrLanguage = "C#";
+            pguidLanguage = DebugEngineGuids.guidLanguageCs;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Gets the name of the stack frame.
+        // The name of a stack frame is typically the name of the method being executed.
+        int IDebugStackFrame2.GetName(out string name)
+        {name = null;
+
+            try
+            {
+                name = _stackFrame.SourceLocation.MethodName;
+
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Gets a machine-dependent representation of the range of physical addresses associated with a stack frame.
+        int IDebugStackFrame2.GetPhysicalStackRange(out ulong addrMin, out ulong addrMax)
+        {
+            addrMin = 0;
+            addrMax = 1;
+            return VisualStudioExtensionConstants.S_OK;
+            /*
+            addrMin = m_threadContext.ebp;
+            addrMax = m_threadContext.ebp;
+
+            return VisualStudioExtensionConstants.S_OK;*/
+        }
+
+        // Gets the thread associated with a stack frame.
+        int IDebugStackFrame2.GetThread(out IDebugThread2 thread)
+        {
+            thread = _thread;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        #endregion
+
+        #region IDebugExpressionContext2 Members
+
+        // Retrieves the name of the evaluation context. 
+        // The name is the description of this evaluation context. It is typically something that can be parsed by an expression evaluator 
+        // that refers to this exact evaluation context. For example, in C++ the name is as follows: 
+        // "{ function-name, source-file-name, module-file-name }"
+        int IDebugExpressionContext2.GetName(out string pbstrName)
+        {
+            throw new NotImplementedException();
+        }
+
+        private XamarinExpression ParseThisInternals(Mono.Debugging.Client.ObjectValue parent, string pszCode)
+        {
+            foreach (var currVariable in parent.GetAllChildren())
+            {
+                if (String.CompareOrdinal(currVariable.Name, "base") == 0 ||
+                    String.CompareOrdinal(currVariable.Name, "Non-public members") == 0)
+                {
+                    var result = ParseThisInternals(currVariable, pszCode);
+                    if (result != null)
+                        return result;
+                }
+                if (String.CompareOrdinal(currVariable.Name, pszCode) == 0)
+                {
+                    return new XamarinExpression(_engine, _thread, currVariable);
+                }
+            }
+            return null;
+        }
+
+        // Parses a text-based expression for evaluation.
+        int IDebugExpressionContext2.ParseText(string pszCode,
+                                                enum_PARSEFLAGS dwFlags, 
+                                                uint nRadix, 
+                                                out IDebugExpression2 ppExpr, 
+                                                out string pbstrError, 
+                                                out uint pichError)
+        {
+            pbstrError = "";
+            pichError = 0;
+            ppExpr = null;
+
+            try
+            {               
+                // Check if the expression belongs to the parameters
+                foreach (var currVariable in _parameters)
+                {
+                    if (String.CompareOrdinal(currVariable.Name, pszCode) == 0)
+                    {
+                        ppExpr = new XamarinExpression(_engine, _thread, currVariable);
+                        return VisualStudioExtensionConstants.S_OK;
+                    }
+                }
+
+                // Check if the expression belongs to the locals
+                foreach (var currVariable in _locals)
+                {
+                    if (String.CompareOrdinal(currVariable.Name, pszCode) == 0)
+                    {
+                        ppExpr = new XamarinExpression(_engine, _thread, currVariable);
+                        return VisualStudioExtensionConstants.S_OK;
+                    }
+                }
+
+                if(_thisObject != null)
+                {
+                    // Are we looking for "this"?
+                    if (String.CompareOrdinal("this", pszCode) == 0)
+                    {
+                        ppExpr = new XamarinExpression(_engine, _thread, _thisObject);
+                        return VisualStudioExtensionConstants.S_OK;
+                    }
+
+                    // Lastly, check if it's a member of this 
+                    var parsedExpression = ParseThisInternals(_thisObject, pszCode);
+                    if(parsedExpression != null)
+                    {
+                        ppExpr = parsedExpression;
+                        return VisualStudioExtensionConstants.S_OK;
+                    }
+                }
+
+                pbstrError = "Invalid Expression";
+                pichError = (uint)pbstrError.Length;
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        #endregion
+    }
+}
+

--- a/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinThread.cs
+++ b/VSMonoDebugger/Mono.Debugging.VisualStudio/XamarinThread.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.Debugger.Interop;
+using System.Diagnostics;
+using VSMonoDebugger;
+using VSMonoDebugger.Services;
+using Mono.Debugging.Soft;
+
+namespace Mono.Debugging.VisualStudio
+{
+    class XamarinThread : IDebugThread2
+    {
+        readonly XamarinEngine _engine;
+        readonly long _id;
+        readonly string _name;
+        readonly string _location;
+        readonly SoftDebuggerSession _session;
+
+        public XamarinThread(XamarinEngine engine, long id, string name, string location, SoftDebuggerSession session)
+        {
+            _engine = engine;
+            _id = id;
+            _name = name;
+            _location = location;
+            _session = session;
+        }      
+
+        #region IDebugThread2 Members
+
+        // Determines whether the next statement can be set to the given stack frame and code context.
+        int IDebugThread2.CanSetNextStatement(IDebugStackFrame2 stackFrame, IDebugCodeContext2 codeContext)
+        {
+            return VisualStudioExtensionConstants.S_FALSE;
+        }
+
+        // Retrieves a list of the stack frames for this thread.
+        // For the sample engine, enumerating the stack frames requires walking the callstack in the debuggee for this thread
+        // and coverting that to an implementation of IEnumDebugFrameInfo2. 
+        // Real engines will most likely want to cache this information to avoid recomputing it each time it is asked for,
+        // and or construct it on demand instead of walking the entire stack.
+        int IDebugThread2.EnumFrameInfo(enum_FRAMEINFO_FLAGS dwFieldSpec, uint nRadix, out IEnumDebugFrameInfo2 enumObject)
+        {
+            enumObject = null;
+
+            if(_session.ActiveThread.Id != _id)
+            {
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+
+            if (_session.ActiveThread.Backtrace.FrameCount > 0)
+            {
+                try
+                {
+                    FRAMEINFO[] frameInfoArray;
+
+                    if (_session.ActiveThread.Backtrace.FrameCount == 1)
+                    {
+                        // failed to walk any frames. Only return the top frame.
+                        frameInfoArray = new FRAMEINFO[1];
+                        XamarinStackFrame frame = new XamarinStackFrame(_engine, this, _session.ActiveThread.Backtrace.GetFrame(0));
+                        frameInfoArray[0] = frame.CreateFrameInfo(dwFieldSpec);
+                    }
+                    else
+                    {
+                        frameInfoArray = new FRAMEINFO[_session.ActiveThread.Backtrace.FrameCount];
+
+                        for (int i = 0; i < _session.ActiveThread.Backtrace.FrameCount; i++)
+                        {
+                            XamarinStackFrame frame = new XamarinStackFrame(_engine, this, _session.ActiveThread.Backtrace.GetFrame(i));
+                            frameInfoArray[i] = frame.CreateFrameInfo(dwFieldSpec);
+                        }
+                    }
+
+                    enumObject = new XamarinFrameInfoEnum(frameInfoArray);
+                    return VisualStudioExtensionConstants.S_OK;
+                }
+                catch (ComponentException e)
+                {
+                    return e.HResult;
+                }
+                catch (Exception e)
+                {
+                    NLogService.Logger.Error(e);
+                    return VisualStudioExtensionConstants.S_FALSE;
+                }
+            }
+
+            return VisualStudioExtensionConstants.S_FALSE;
+        }
+
+        // Get the name of the thread. For the sample engine, the name of the thread is always "Sample Engine Thread"
+        int IDebugThread2.GetName(out string threadName)
+        {
+            threadName = _name;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Return the program that this thread belongs to.
+        int IDebugThread2.GetProgram(out IDebugProgram2 program)
+        {
+            program = _engine.ActiveProgram;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Gets the system thread identifier.
+        int IDebugThread2.GetThreadId(out uint threadId)
+        {
+            threadId = (uint)_id;
+            return VisualStudioExtensionConstants.S_OK;
+        }
+
+        // Gets properties that describe a thread.
+        int IDebugThread2.GetThreadProperties(enum_THREADPROPERTY_FIELDS dwFields, THREADPROPERTIES[] propertiesArray)
+        {
+            try
+            {
+                THREADPROPERTIES props = new THREADPROPERTIES();
+
+                if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_ID) != 0)
+                {
+                    props.dwThreadId = (uint)_id;
+                    props.dwFields |= enum_THREADPROPERTY_FIELDS.TPF_ID;
+                }
+                if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_SUSPENDCOUNT) != 0) 
+                {
+                    // sample debug engine doesn't support suspending threads
+                    props.dwFields |= enum_THREADPROPERTY_FIELDS.TPF_SUSPENDCOUNT;
+                }
+                if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_STATE) != 0) 
+                {
+                    props.dwThreadState = (uint)enum_THREADSTATE.THREADSTATE_RUNNING;
+                    props.dwFields |= enum_THREADPROPERTY_FIELDS.TPF_STATE;
+                }
+                if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_PRIORITY) != 0) 
+                {
+                    props.bstrPriority = "Normal";
+                    props.dwFields |= enum_THREADPROPERTY_FIELDS.TPF_PRIORITY;
+                }
+                if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_NAME) != 0)
+                {
+                    props.bstrName = _name;
+                    props.dwFields |= enum_THREADPROPERTY_FIELDS.TPF_NAME;
+                }
+                if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_LOCATION) != 0)
+                {
+                    props.bstrLocation = _location;
+                    props.dwFields |= enum_THREADPROPERTY_FIELDS.TPF_LOCATION;
+                }
+
+                return VisualStudioExtensionConstants.S_OK;
+            }
+            catch (ComponentException e)
+            {
+                return e.HResult;
+            }
+            catch (Exception e)
+            {
+                NLogService.Logger.Error(e);
+                return VisualStudioExtensionConstants.S_FALSE;
+            }
+        }
+
+        // Resume a thread.
+        // This is called when the user chooses "Unfreeze" from the threads window when a thread has previously been frozen.
+        int IDebugThread2.Resume(out uint suspendCount)
+        {
+            suspendCount = 0;
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        // Sets the next statement to the given stack frame and code context.
+        int IDebugThread2.SetNextStatement(IDebugStackFrame2 stackFrame, IDebugCodeContext2 codeContext)
+        {
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        // suspend a thread.
+        // This is called when the user chooses "Freeze" from the threads window
+        int IDebugThread2.Suspend(out uint suspendCount)
+        {
+            suspendCount = 0;
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        #endregion
+
+        #region Uncalled interface methods
+        // These methods are not currently called by the Visual Studio debugger, so they don't need to be implemented
+
+        int IDebugThread2.GetLogicalThread(IDebugStackFrame2 stackFrame, out IDebugLogicalThread2 logicalThread)
+        {
+            Debug.Fail("This function is not called by the debugger");
+
+            logicalThread = null;
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        int IDebugThread2.SetThreadName(string name)
+        {
+            Debug.Fail("This function is not called by the debugger");
+            
+            return VisualStudioExtensionConstants.E_NOTIMPL;
+        }
+
+        #endregion
+    }
+}

--- a/VSMonoDebugger/Properties/AssemblyInfo.cs
+++ b/VSMonoDebugger/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.3.0")]
-[assembly: AssemblyFileVersion("0.9.3.0")]
+[assembly: AssemblyVersion("0.9.4.0")]
+[assembly: AssemblyFileVersion("0.9.4.0")]

--- a/VSMonoDebugger/Services/DebugEngineGuids.cs
+++ b/VSMonoDebugger/Services/DebugEngineGuids.cs
@@ -78,5 +78,41 @@ namespace VSMonoDebugger.Services
         {
             get { return s_guidLanguageC; }
         }
+
+        static private Guid s_guidFilterRegisters = new Guid("223ae797-bd09-4f28-8241-2763bdc5f713");
+        static public Guid guidFilterRegisters
+        {
+            get { return s_guidFilterRegisters; }
+        }
+
+        static private Guid s_guidFilterLocals = new Guid("b200f725-e725-4c53-b36a-1ec27aef12ef");
+        static public Guid guidFilterLocals
+        {
+            get { return s_guidFilterLocals; }
+        }
+
+        static private Guid s_guidFilterAllLocals = new Guid("196db21f-5f22-45a9-b5a3-32cddb30db06");
+        static public Guid guidFilterAllLocals
+        {
+            get { return s_guidFilterAllLocals; }
+        }
+
+        static private Guid s_guidFilterArgs = new Guid("804bccea-0475-4ae7-8a46-1862688ab863");
+        static public Guid guidFilterArgs
+        {
+            get { return s_guidFilterArgs; }
+        }
+
+        static private Guid s_guidFilterLocalsPlusArgs = new Guid("e74721bb-10c0-40f5-807f-920d37f95419");
+        static public Guid guidFilterLocalsPlusArgs
+        {
+            get { return s_guidFilterLocalsPlusArgs; }
+        }
+
+        static private Guid s_guidFilterAllLocalsPlusArgs = new Guid("939729a8-4cb0-4647-9831-7ff465240d5f");
+        static public Guid guidFilterAllLocalsPlusArgs
+        {
+            get { return s_guidFilterAllLocalsPlusArgs; }
+        }
     }
 }

--- a/VSMonoDebugger/Services/VisualStudioExtensionConstants.cs
+++ b/VSMonoDebugger/Services/VisualStudioExtensionConstants.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using NLog;
+using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+using Task = System.Threading.Tasks.Task;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Diagnostics;
+using VSMonoDebugger.Services;
+using VSMonoDebugger.Settings;
+using Mono.Debugging.VisualStudio;
+
+namespace VSMonoDebugger
+{
+    class VisualStudioExtensionConstants
+    {
+        static public int S_OK = 0;
+        static public int S_FALSE = 1;
+        static public int E_NOTIMPL = unchecked((int)0x80004001);
+        static public int E_FAIL = unchecked((int)0x80004005);
+    }
+}

--- a/VSMonoDebugger/VSMonoDebugger.csproj
+++ b/VSMonoDebugger/VSMonoDebugger.csproj
@@ -55,14 +55,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinDocumentContext.cs" />
     <Compile Include="Mono.Debugging.VisualStudio\XamarinEngine.cs" />
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinEnums.cs" />
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinExpression.cs" />
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinEvents.cs" />
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinMemoryAddress.cs" />
     <Compile Include="Mono.Debugging.VisualStudio\XamarinPortSupplier.cs" />
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinProperty.cs" />
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinStackFrame.cs" />
+    <Compile Include="Mono.Debugging.VisualStudio\XamarinThread.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DebugEngineGuids.cs" />
     <Compile Include="Services\DebugEngineInstallService.cs" />
     <Compile Include="Services\HostOutputWindowEx.cs" />
     <Compile Include="Services\NLogService.cs" />
     <Compile Include="Services\MonoVisualStudioExtension.cs" />
+    <Compile Include="Services\VisualStudioExtensionConstants.cs" />
     <Compile Include="Settings\UserSettingsContainer.cs" />
     <Compile Include="Settings\UserSettingsManager.cs" />
     <Compile Include="Settings\DebugOptions.cs" />


### PR DESCRIPTION
Add support for stack frames and expressions evaluation. This enables the watch window, hovering over variables, the locals window and the callstack window.

This has been tested against an embedded mono project.