### PR TITLE
reduced cpu usage

### DIFF
--- a/VSMonoDebugger/Debuggers/LocalWindowsDebugger.cs
+++ b/VSMonoDebugger/Debuggers/LocalWindowsDebugger.cs
@@ -156,7 +156,11 @@ namespace VSMonoDebugger.Debuggers
                 while (!asynch.IsCompleted)
                 {
                     var result = await reader.ReadToEndAsync();
-                    if (!string.IsNullOrEmpty(result))
+                    if (string.IsNullOrEmpty(result))
+                    {
+                        System.Threading.Thread.Sleep(1);
+                    }
+                    else
                     {
                         await writeOutput(result);
                     }

--- a/VSMonoDebugger/Debuggers/SSHDebuggerMono.cs
+++ b/VSMonoDebugger/Debuggers/SSHDebuggerMono.cs
@@ -90,7 +90,11 @@ namespace VSMonoDebugger.Debuggers
                 while (!asynch.IsCompleted)
                 {
                     var result = await reader.ReadToEndAsync();
-                    if (!string.IsNullOrEmpty(result))
+                    if (string.IsNullOrEmpty(result))
+                    {
+                        System.Threading.Thread.Sleep(1);
+                    }
+                    else
                     {
                         await writeOutput(result);
                     }


### PR DESCRIPTION
Remote debugging mono applications used a lot of CPU, making debugging multiple projects impossible. The fix reduces it from 80% on one core to <1%.